### PR TITLE
fix: analytics params (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022-11-18
+### Fixed
+- Incorrect parameter in analytics.logScore
+- Missing parameter in analytics.logTutorialEnd
+
 ## [2.0.0] - 2022-11-18
 ### Breaking Change
 - API access is now by module (wortal.ads, wortal.analytics)

--- a/templates/wortal-api/wortal-analytics.js
+++ b/templates/wortal-api/wortal-analytics.js
@@ -40,7 +40,7 @@ module.exports = {
      * @param {string} score Score the player achieved.
      */
     logScore(score) {
-        window.Wortal.analytics.logScore(level);
+        window.Wortal.analytics.logScore(score);
     },
 
     /**
@@ -63,7 +63,7 @@ module.exports = {
      * @param {boolean} wasCompleted Was the tutorial completed.
      */
     logTutorialEnd(tutorial, wasCompleted) {
-        window.Wortal.analytics.logTutorialEnd(tutorial), wasCompleted;
+        window.Wortal.analytics.logTutorialEnd(tutorial, wasCompleted);
     },
 
     /**


### PR DESCRIPTION
This fixes 2 issues in the analytics API:

- Incorrect parameter passed in `logScore`
- Missing parameter in `logTutorialEnd`